### PR TITLE
【Fixed】`rails g`コマンドの際にいらないファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,10 @@ module GithubFlowApp
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.generators do |g|
+      # この二行の記述で自動生成しない設定を作成しています。
+      g.assets false
+      g.helper false
+    end
   end
 end


### PR DESCRIPTION
#1 

helperとassetsファイルが生成されない記述を追加しました